### PR TITLE
feature: Pass along all query params

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import './App.css';
 const iframeOrigin = `https://fast.wistia.${process.env.REACT_APP_WISTIA_TLD}`;
 const searchParams = new URL(document.location.toString()).searchParams;
 const hashedId = searchParams.get('hashedId') ?? '';
+const lang = searchParams.get('lang') ?? '';
 const serverDomain = process.env.REACT_APP_SERVER_ORIGIN;
 
 function App() {
@@ -66,10 +67,13 @@ function App() {
     }
   }, [token, iframeRendered]);
 
+  let url = `${iframeOrigin}/transcript-edit/embed/?hashedId=${hashedId}`
+  url = lang ? `${url}&lang=${lang}` : url
+
   return (
     <div>
       <h1>React in TypeScript embed example</h1>
-      <iframe title="embed" src={`${iframeOrigin}/transcript-edit/embed/?hashedId=${hashedId}`} sandbox="allow-scripts allow-same-origin allow-modals" />
+      <iframe title="embed" src={url} sandbox="allow-scripts allow-same-origin allow-modals" />
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,9 +4,14 @@ import './App.css';
 
 const iframeOrigin = `https://fast.wistia.${process.env.REACT_APP_WISTIA_TLD}`;
 const searchParams = new URL(document.location.toString()).searchParams;
-const hashedId = searchParams.get('hashedId') ?? '';
-const lang = searchParams.get('lang') ?? '';
 const serverDomain = process.env.REACT_APP_SERVER_ORIGIN;
+
+// Pass along query params from the test app to the iframe
+const constructIframeUrl = () => {
+  const baseUrl = `${iframeOrigin}/transcript-edit/embed/?`;
+  const params = new URLSearchParams(searchParams);
+  return baseUrl + params.toString();
+};
 
 function App() {
   const [token, setToken] = useState<string | undefined>()
@@ -16,6 +21,7 @@ function App() {
     const controller = new AbortController()
 
     async function setTokenFromServer() {
+      const hashedId = searchParams.get('hashedId')
       const response = await fetch(`${serverDomain}/expiring_token/${hashedId}`, { signal: controller.signal })
       const json = await response.json()
       const tokenFromServer = json.token
@@ -67,8 +73,7 @@ function App() {
     }
   }, [token, iframeRendered]);
 
-  let url = `${iframeOrigin}/transcript-edit/embed/?hashedId=${hashedId}`
-  url = lang ? `${url}&lang=${lang}` : url
+  const url = constructIframeUrl();
 
   return (
     <div>


### PR DESCRIPTION
Refactors the test app to pass along all query params in the iframe src url. This is useful for testing the lang query param that I'll be adding soon.