### PR TITLE
Make default frontend iframe be .net

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ restart docker. For changes to the frontend you just need to refresh the page.
 
 ## Pointing to a different TLD
 
-By default we route all requests to `*.wistia.com`. If you are doing local wistia
+By default we route all requests to `fast.wistia.net` for the iframe and `app.wistia.com` for the token requests. If you are doing local wistia
 development or want to point to staging instead you will need to change this. Simply
 specify a different TLD:
 
 ```sh
 # NOTE: this needs to be a different token than what points to the .com mentioned
 # above.
-WISTIA_PERMANENT_TOKEN=<a-token-you-created-in-appropriate-env> WISTIA_TLD=io docker compose up
+WISTIA_PERMANENT_TOKEN=<a-token-you-created-in-appropriate-env> WISTIA_FRONTEND_TLD=io WISTIA_BACKEND_TLD=io docker compose up
 ```

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,7 +5,7 @@ import { Request, Response, NextFunction } from 'express';
 const app = express();
 const port = Number(process.env.SERVER_PORT);
 const permanentToken = process.env.WISTIA_PERMANENT_TOKEN
-const wistiaHost = `api.wistia.${process.env.WISTIA_TLD}`;
+const wistiaHost = `api.wistia.${process.env.WISTIA_BACKEND_TLD}`;
 
 if (!permanentToken) {
   throw new Error('The WISTIA_PERMANENT_TOKEN environment variable must be set')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     command: npm start
     entrypoint: /backend/entrypoint
     environment:
-      - WISTIA_TLD=${WISTIA_TLD:-com}
+      - WISTIA_BACKEND_TLD=${WISTIA_BACKEND_TLD:-com}
       - SERVER_PORT=${SERVER_PORT:-5151}
       - WISTIA_PERMANENT_TOKEN
     extra_hosts:
@@ -32,7 +32,7 @@ services:
     command: npm start
     entrypoint: /frontend/entrypoint
     environment:
-      - REACT_APP_WISTIA_TLD=${WISTIA_TLD:-com}
+      - REACT_APP_WISTIA_TLD=${WISTIA_FRONTEND_TLD:-net}
       - REACT_APP_SERVER_ORIGIN=${REACT_APP_SERVER_ORIGIN:-http://localhost:5050}
       - PORT=5252
   frontend-vanilla:

--- a/frontend-vanilla/index.html
+++ b/frontend-vanilla/index.html
@@ -20,7 +20,7 @@
   <script>
     const searchParams = new URL(document.location.toString()).searchParams;
     const hashedId = searchParams.get('hashedId') || '';
-    const tld = searchParams.get('tld') || 'com';
+    const tld = searchParams.get('tld') || 'net';
     const iframeOrigin = `https://fast.wistia.${tld}`;
 
     async function grabTokenFromServer() {


### PR DESCRIPTION
See https://wistia.slack.com/archives/C04SW1FJ8CU/p1732147799503829. Essentially `fast.wistia.net` is what we want for iframes, not `fast.wistia.com`.

I also edited the page at https://dash.readme.com/project/wistia/v1.0/docs/transcript-editing-embeds but could use a second set of eyes there to make sure I got all the `fast.wistia.com` ones.

## Testing steps

If you don't already have one, create a permanent access token to home.wistia.com, save it somewhere secure. Run the following:

```bash
WISTIA_PERMANENT_TOKEN=<the-token-you-just-created> docker compose up
```

Ensure that visiting http://localhost:5050/frontend-vanilla?hashedId=age4b1p18f loads the page correctly in firefox.