### PR TITLE
Tdevries/make iframe tester compatible with branch deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ specify a different TLD:
 # above.
 WISTIA_PERMANENT_TOKEN=<a-token-you-created-in-appropriate-env> WISTIA_FRONTEND_TLD=io WISTIA_BACKEND_TLD=io docker compose up
 ```
+
+## Pointing to a branch deploy
+
+If you want to test against a branch deploy, you can supply `BRANCH_DEPLOY_PR_NUMBER`:
+
+```sh
+WISTIA_PERMANENT_TOKEN=<a-token-you-created-in-appropriate-env> WISTIA_FRONTEND_TLD=st WISTIA_BACKEND_TLD=st BRANCH_DEPLOY_PR_NUMBER=<pr-number> docker compose up
+```

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,7 +5,8 @@ import { Request, Response, NextFunction } from 'express';
 const app = express();
 const port = Number(process.env.SERVER_PORT);
 const permanentToken = process.env.WISTIA_PERMANENT_TOKEN
-const wistiaHost = `api.wistia.${process.env.WISTIA_BACKEND_TLD}`;
+const branchSuffix = process.env.BRANCH_DEPLOY_PR_NUMBER ? `-branch-${process.env.BRANCH_DEPLOY_PR_NUMBER}` : '';
+const wistiaHost = `api${branchSuffix}.wistia.${process.env.WISTIA_BACKEND_TLD}`;
 
 if (!permanentToken) {
   throw new Error('The WISTIA_PERMANENT_TOKEN environment variable must be set')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - WISTIA_BACKEND_TLD=${WISTIA_BACKEND_TLD:-com}
       - SERVER_PORT=${SERVER_PORT:-5151}
       - WISTIA_PERMANENT_TOKEN
+      - BRANCH_DEPLOY_PR_NUMBER
     extra_hosts:
       # Needed if pointing to localhost dev
       - api.wistia.io:host-gateway
@@ -35,6 +36,7 @@ services:
       - REACT_APP_WISTIA_TLD=${WISTIA_FRONTEND_TLD:-net}
       - REACT_APP_SERVER_ORIGIN=${REACT_APP_SERVER_ORIGIN:-http://localhost:5050}
       - PORT=5252
+      - REACT_APP_BRANCH_DEPLOY_PR_NUMBER=${BRANCH_DEPLOY_PR_NUMBER}
   frontend-vanilla:
     image: nginx:1.23-alpine
     volumes:

--- a/frontend-vanilla/index.html
+++ b/frontend-vanilla/index.html
@@ -21,7 +21,9 @@
     const searchParams = new URL(document.location.toString()).searchParams;
     const hashedId = searchParams.get('hashedId') || '';
     const tld = searchParams.get('tld') || 'net';
-    const iframeOrigin = `https://fast.wistia.${tld}`;
+    const branchDeployPrNumber = searchParams.get('branchDeployPrNumber');
+    const branchSuffix = branchDeployPrNumber ? `-branch-${branchDeployPrNumber}` : '';
+    const iframeOrigin = `https://fast${branchSuffix}.wistia.${tld}`;
 
     async function grabTokenFromServer() {
       const response = await fetch(`http://localhost:5050/expiring_token/${hashedId}`);
@@ -55,7 +57,7 @@
 
     function insertIFrameIntoDocument() {
       document.querySelector('#iframe-container')
-        .insertAdjacentHTML('beforeend', `<iframe title="embed" src="https://fast.wistia.${tld}/transcript-edit/embed/?hashedId=${hashedId}" sandbox="allow-scripts allow-same-origin allow-modals" />`);
+        .insertAdjacentHTML('beforeend', `<iframe title="embed" src="${iframeOrigin}/transcript-edit/embed/?hashedId=${hashedId}" sandbox="allow-scripts allow-same-origin allow-modals" />`);
     }
 
     function sendTokenToIframe(tokenFromServer) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { useState, useEffect } from 'react';
 import './App.css';
 
-const iframeOrigin = `https://fast.wistia.${process.env.REACT_APP_WISTIA_TLD}`;
+const branchSuffix = process.env.REACT_APP_BRANCH_DEPLOY_PR_NUMBER ? `-branch-${process.env.REACT_APP_BRANCH_DEPLOY_PR_NUMBER}` : '';
+const iframeOrigin = `https://fast${branchSuffix}.wistia.${process.env.REACT_APP_WISTIA_TLD}`;
 const searchParams = new URL(document.location.toString()).searchParams;
 const serverDomain = process.env.REACT_APP_SERVER_ORIGIN;
 


### PR DESCRIPTION
Branch deploys can now be specified with `BRANCH_DEPLOY_PR_NUMBER`. This needs to be combined with `WISTIA_FRONTEND_TLD` and `WISTIA_BACKEND_TLD` to point to staging. For example:

```sh
WISTIA_PERMANENT_TOKEN=<token> WISTIA_FRONTEND_TLD=st WISTIA_BACKEND_TLD=st BRANCH_DEPLOY_PR_NUMBER=37470 docker compose up
```

can be used to point to PR number 37470